### PR TITLE
Allow only array params in init method

### DIFF
--- a/src/Commands/HandlesCommandInternals.php
+++ b/src/Commands/HandlesCommandInternals.php
@@ -24,24 +24,8 @@ trait HandlesCommandInternals
     /**
      * {@inheritdoc}
      */
-    public function init($arguments_definition, $options_definition): void
+    public function init(array $arguments_definition, array $options_definition): void
     {
-        if (is_string($arguments_definition)) {
-            if (!property_exists($this, $arguments_definition) || !is_array($this->{$arguments_definition})) {
-                $arguments_definition = [];
-            }
-
-            $arguments_definition = $this->{$arguments_definition};
-        }
-
-        if (is_string($options_definition)) {
-            if (!property_exists($this, $options_definition) || !is_array($this->{$options_definition})) {
-                $options_definition = [];
-            }
-
-            $options_definition = $this->{$options_definition};
-        }
-
         $this->arguments = ArgumentsCollection::create($arguments_definition);
         $this->options = OptionsCollection::create($options_definition);
     }

--- a/src/FluidCommand.php
+++ b/src/FluidCommand.php
@@ -15,10 +15,10 @@ interface FluidCommand
     /**
      * Initializes the command compiling the arguments and options collections.
      *
-     * @param string|array $arguments_definition The arguments definition property name or the actual definition array
-     * @param string|array $options_definition   The options definition property name or the actual definition array
+     * @param array $arguments_definition The arguments definition array
+     * @param array $options_definition   The options definition array
      */
-    public function init($arguments_definition, $options_definition): void;
+    public function init(array $arguments_definition, array $options_definition): void;
 
     /**
      * Gets the command name.


### PR DESCRIPTION
I'm wondering if it makes sense to have the ability to 'proxy' the definition calls in the `init` method to another property name (passing strings to the `init method instead of arrays).

I'm also leaning towards that not being the `init` method's responsibility (deciding which value to use for initializing).