### PR TITLE
Refactor tests to not include implementation details

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,7 @@ parameters:
           path: %currentWorkingDirectory%/tests/Unit/ArgumentsCollectionTest.php
         - message: '~Parameter #1 $key of method [a-zA-Z0-9\\_]+::validateIdentifier() expects int|string, stdClass given.~'
           path: %currentWorkingDirectory%/tests/Unit/OptionsCollectionTest.php
+        - message: '~Trying to invoke (callable(): mixed)|null but it might not be a callable.~'
+          path: %currentWorkingDirectory%/tests/Unit/ArgumentsCollectionTest.php
+        - message: '~Trying to invoke (callable(): mixed)|null but it might not be a callable.~'
+          path: %currentWorkingDirectory%/tests/Unit/OptionsCollectionTest.php

--- a/src/Collections/BaseCollection.php
+++ b/src/Collections/BaseCollection.php
@@ -130,14 +130,6 @@ abstract class BaseCollection implements CompilableCollection
     /**
      * {@inheritdoc}
      */
-    public function getControl(): array
-    {
-        return $this->control;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getItems(): array
     {
         return $this->items;

--- a/src/Collections/CompilableCollection.php
+++ b/src/Collections/CompilableCollection.php
@@ -69,13 +69,6 @@ interface CompilableCollection
     public function getDefinition(): array;
 
     /**
-     * Gets the collection control structure.
-     *
-     * @return array
-     */
-    public function getControl(): array;
-
-    /**
      * Get the collection's raw internal items array.
      *
      * @return array

--- a/src/Commands/Arguments/ArgumentsCollection.php
+++ b/src/Commands/Arguments/ArgumentsCollection.php
@@ -80,7 +80,7 @@ class ArgumentsCollection extends BaseCollection
 
         if (!\is_array($argument)) {
             throw new \UnexpectedValueException(sprintf(
-                'The argument spec must be a string or an array, %s given',
+                'The argument spec must be a string or an array, \'%s\' given.',
                 gettype($argument)
             ));
         }

--- a/src/Commands/Options/OptionsCollection.php
+++ b/src/Commands/Options/OptionsCollection.php
@@ -84,7 +84,7 @@ class OptionsCollection extends BaseCollection
 
         if (!\is_array($option)) {
             throw new \UnexpectedValueException(sprintf(
-                'The option spec must be a string or an array, %s given',
+                'The option spec must be a string or an array, \'%s\' given.',
                 gettype($option)
             ));
         }
@@ -236,6 +236,19 @@ class OptionsCollection extends BaseCollection
         }
 
         return (bool)preg_match('/^\-{1,2}[a-zA-Z](?:[a-zA-Z0-9_\-]|\|\-{1,2}[a-zA-Z])*(?<!\-)$/', (string)$key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(): array
+    {
+        $items = [];
+        foreach ($this->items as $hash => $item) {
+            $items[$item['key']] = $item['value'];
+        }
+
+        return $items;
     }
 
     /**


### PR DESCRIPTION
Exposing the control array (implementation detail) made no sense. The
test were testing specificities of this array instead of the behavior
the collections should have.
